### PR TITLE
Patch DB model bugs

### DIFF
--- a/sfrCore/model/agent.py
+++ b/sfrCore/model/agent.py
@@ -1,3 +1,4 @@
+import copy
 import re
 import requests
 from dateutil.parser import parse
@@ -88,13 +89,13 @@ class Agent(Core, Base):
         """Evaluates whether a matching record exists and either updates that
         agent record or creates a new one"""
 
-        agentRec, roles = Agent.createAgent(session, agentData)
+        agentRec, roles = Agent.createAgent(session, copy.deepcopy(agentData))
         existingAgentID = agentRec.lookup()
 
         if existingAgentID is not None:
             existingAgent = session.query(cls).get(existingAgentID)
-            roles = existingAgent.update(session, agentData)
-            return existingAgent, roles
+            updateRoles = existingAgent.update(session, agentData)
+            return existingAgent, list(set(roles) | set(updateRoles))
 
 
         return agentRec, roles

--- a/sfrCore/model/identifiers.py
+++ b/sfrCore/model/identifiers.py
@@ -418,4 +418,4 @@ class Identifier(Base):
         trueIdentifiers = list(
             filter(lambda x: x['type'] not in['lcc', 'ddc'], identifiers)
         )
-        return sorted(trueIdentifiers, key=lambda x:idWeight[x['type']])
+        return sorted(trueIdentifiers, key=lambda x:idWeight.get(x['type'], 10))

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -318,6 +318,7 @@ class Instance(Core, Base):
             logger.warning('Unable to parse language {}'.format(lang))
     
     def insertItems(self):
+        setattr(self, 'epubsToLoad', [])
         for item in self.tmp_formats:
             # Check if the provided record contains an epub that can be stored
             # locally. If it does, defer insert to epub creation process

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -406,6 +406,11 @@ class AgentInstances(Core, Base):
     )
     agent = relationship('Agent')
 
+    def __init__(self, instance=None, agent=None, role=None):
+        self.instance= instance
+        self.agent = agent
+        self.role = role
+
     @classmethod
     def roleExists(cls, session, agent, role, recordID):
         """Query database to see if relationship with role exists between

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -208,6 +208,7 @@ class Instance(Core, Base):
     def update(self, session, instanceData):
         """Update an existing instance"""
         
+        self.session = session
         # Set fields targeted for works
         if self.work is not None:
             self.setWorkFields(
@@ -216,7 +217,6 @@ class Instance(Core, Base):
                 instanceData.pop('subjects', [])
             )
 
-        self.session = session
         self.createTmpRelations(instanceData)
 
         for field, value in instanceData.items():

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -168,7 +168,7 @@ class Instance(Core, Base):
     @classmethod
     def addItemRecord(cls, session, instanceID, itemRec):
         instance = session.query(cls).get(instanceID)
-        instance.items.append(itemRec)
+        instance.items.add(itemRec)
 
     @classmethod
     def createNew(cls, session, instanceData):

--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -135,7 +135,11 @@ class Item(Core, Base):
                                 session.flush()
 
                             deferredLoad = True
-                            localPayload = cls.createLocalEpub(item, link)
+                            localPayload = cls.createLocalEpub(
+                                item,
+                                link,
+                                instance.id
+                            )
                             instance.epubsToLoad.append(localPayload)
                             break
                 except TypeError as err:
@@ -151,7 +155,7 @@ class Item(Core, Base):
         return None
 
     @classmethod
-    def createLocalEpub(cls, item, link):
+    def createLocalEpub(cls, item, link, instanceID):
         """Pass new item to epub storage pipeline. Does not store item record
         at this time, but defers until epub has been processed.
         The payload object takes several parameters:
@@ -163,7 +167,7 @@ class Item(Core, Base):
         putItem['links'] = [link]
         epubPayload = {
             'url': link['url'],
-            'id': instance.id,
+            'id': instanceID,
             'updated': item['modified'],
             'data': putItem
         }

--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -119,7 +119,6 @@ class Item(Core, Base):
         links = deque(item.pop('links', []))
         item['links'] = []
         deferredLoad = False
-        instance.epubsToLoad = []
         while len(links) > 0:
             link = links.popleft()
             url = link['url']
@@ -128,7 +127,6 @@ class Item(Core, Base):
                 try:
                     if re.search(regex, url):
                         if source in cls.EPUB_SOURCES:
-
                             # We need to get the ID of the instance to allow 
                             # for asynchronously storing the ePub file, so
                             # instance is added and flushed here
@@ -137,7 +135,8 @@ class Item(Core, Base):
                                 session.flush()
 
                             deferredLoad = True
-                            cls.createLocalEpub(item, link, instance)
+                            localPayload = cls.createLocalEpub(item, link)
+                            instance.epubsToLoad.append(localPayload)
                             break
                 except TypeError as err:
                     logger.warning('Found link {} with no url {}'.format(
@@ -152,7 +151,7 @@ class Item(Core, Base):
         return None
 
     @classmethod
-    def createLocalEpub(cls, item, link, instance):
+    def createLocalEpub(cls, item, link):
         """Pass new item to epub storage pipeline. Does not store item record
         at this time, but defers until epub has been processed.
         The payload object takes several parameters:
@@ -173,7 +172,7 @@ class Item(Core, Base):
             if measure['quantity'] == 'bytes':
                 epubPayload['size'] = measure['value']
                 break
-        instance.epubsToLoad.append(epubPayload)
+        return epubPayload
 
     @classmethod
     def updateOrInsert(cls, session, itemData):

--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -422,6 +422,11 @@ class AgentItems(Core, Base):
     )
     agent = relationship('Agent')
 
+    def __init__(self, item=None, agent=None, role=None):
+        self.item = item
+        self.agent = agent
+        self.role = role
+
     @classmethod
     def roleExists(cls, session, agent, role, recordID):
         """Query database to check if a role exists between a specific work and

--- a/sfrCore/model/measurement.py
+++ b/sfrCore/model/measurement.py
@@ -139,9 +139,11 @@ class Measurement(Core, Base):
     
     @classmethod
     def getMeasurements(cls, session, measure, model, recordID):
-        return session.query(cls.value)\
+        return [ 
+            m.value for m in session.query(cls.value)\
             .join(model.__tablename__[:-1])\
             .filter(cls.quantity == measure)\
             .filter(model.id == recordID)\
             .all()
+        ]
 

--- a/sfrCore/model/subject.py
+++ b/sfrCore/model/subject.py
@@ -91,8 +91,8 @@ class Subject(Core, Base):
         
         return newSubject
     
-    def addMeasurements(self):
-        newSubject.measurements = {
+    def addMeasurements(self, measurements):
+        self.measurements = {
             Measurement.insert(m) for m in measurements
         }
 

--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -482,6 +482,11 @@ class AgentWorks(Core, Base):
     )
     agent = relationship('Agent')
 
+    def __init__(self, work=None, agent=None, role=None):
+        self.work = work
+        self.agent = agent
+        self.role = role
+
     def __repr__(self):
         return '<AgentWorks(work={}, agent={}, role={})>'.format(
             self.work_id,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -65,7 +65,7 @@ class TestAgent(unittest.TestCase):
             mock_session.query.return_value.get.return_value = mock_existing
             testAgent, roles = Agent.updateOrInsert(mock_session, 'fakeAgent')
             self.assertEqual(testAgent, mock_existing)
-            self.assertEqual(roles, ['existing', 'test'])
+            self.assertTrue('existing' in roles and 'test' in roles)
 
     @patch.object(Agent, 'addLifespan')
     @patch.object(Agent, 'insertData')

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -72,11 +72,11 @@ class InstanceTest(unittest.TestCase):
     
     def test_add_new_item(self):
         mock_instance = MagicMock()
-        mock_instance.items = []
+        mock_instance.items = set()
         mock_session = MagicMock()
         mock_session.query().get.return_value = mock_instance
         Instance.addItemRecord(mock_session, 1, 'newItem')
-        self.assertEqual(mock_instance.items[0], 'newItem')
+        self.assertEqual(list(mock_instance.items)[0], 'newItem')
     
     @patch.object(Instance, 'createTmpRelations')
     @patch.object(Instance, 'insertData', return_value=['epub'])

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -101,10 +101,9 @@ class ItemTest(unittest.TestCase):
         testLink = {
             'url': 'test_link'
         }
-        mock_inst = MagicMock()
-        mock_inst.epubsToLoad = []
-        Item.createLocalEpub(testItem, testLink, mock_inst)
-        self.assertEqual(len(mock_inst.epubsToLoad), 1)
+        testPayload = Item.createLocalEpub(testItem, testLink, 1)
+        self.assertEqual(testPayload['url'], 'test_link')
+        self.assertEqual(testPayload['id'], 1)
     
     @patch.object(Item, 'lookup', return_value=None)
     @patch.object(Item, 'createItem', return_value='newItem')

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -336,11 +336,9 @@ class WorkTest(unittest.TestCase):
             Work.getByUUID(mock_session, 'uuid')
     
     def test_create_agent_work(self):
-        testRec = AgentWorks(
-            work_id=1,
-            agent_id=1,
-            role='tester'
-        )
+        testRec = AgentWorks(role='tester')
+        testRec.work_id = 1
+        testRec.agent_id = 1
         self.assertEqual(str(testRec), '<AgentWorks(work=1, agent=1, role=tester)>')
     
     def test_role_exists(self):


### PR DESCRIPTION
This continues the process of catching edge cases and bugs in the db model as it goes through more extensive testing. Included in this set of update are:

- Fix to ensure that locally loaded ePub files, which are deferred for later loading, are properly passed between items, instances and works.
- Resolve several measurement issues, including that Subjects are properly measured and that the `getMeasurements` method only returns the desired measurement value.
- Correct discrepancies between lists/sets and append/add operations.
- Resolves a major-ish bug where existing Agents were not properly related to new Instances and Works
