### PR TITLE
Agent sort name validation

### DIFF
--- a/sfrCore/model/agent.py
+++ b/sfrCore/model/agent.py
@@ -11,7 +11,7 @@ from sqlalchemy import (
     Unicode,
     or_
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, validates
 from sqlalchemy.sql import text
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
@@ -54,6 +54,19 @@ class Agent(Core, Base):
         back_populates='agents',
         collection_class=set
     )
+
+    @validates('sort_name')
+    def convertSortLower(self, key, name):
+        """Ensures that all sort_name values are stored as lowercase strings
+        
+        Arguments:
+            key {str} -- Field being validated
+            name {str} -- The sort_name value for the current record
+        
+        Returns:
+            str -- The lowercased value for the sort_name
+        """
+        return name.lower()
 
     VIAF_API = 'https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup?queryName='  # noqa: E501
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -138,7 +138,7 @@ class TestAgent(unittest.TestCase):
         
         testRoles = testAgent.insertData(newData)
         self.assertEqual(testAgent.name, 'New, Name')
-        self.assertEqual(testAgent.sort_name, 'New, Name')
+        self.assertEqual(testAgent.sort_name, 'new, name')
 
     
     @patch.object(Agent, 'findJaroWinklerQuery', return_value='mockAgent')


### PR DESCRIPTION
Coerces the `sort_name` field for `agents` to be lower case, which is necessary for correct sorting