### PR TITLE
SFR-573 Add Unicode normalization

### DIFF
--- a/sfrCore/model/core.py
+++ b/sfrCore/model/core.py
@@ -1,5 +1,7 @@
+import unicodedata
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import Column, DateTime, Unicode
+from sqlalchemy.event import listens_for
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
 
@@ -7,7 +9,38 @@ from ..helpers import createLog
 
 Base = declarative_base()
 
+
+def validate_unicode(value):
+    if value is None:
+        return value
+    if isinstance(value, bytes):
+        value = value.decode('utf-8')
+    assert isinstance(value, str)
+    return unicodedata.normalize('NFC', value)
+
+
+validators = {
+    Unicode: validate_unicode
+}
+
+
+# Add unicode validator to normalize all strings to NFC style, not NFD
+@listens_for(Base, 'attribute_instrument')
+def configure_unicode_listener(dbClass, key, inst):
+    if not hasattr(inst.property, 'columns'):
+        return
+
+    @listens_for(inst, 'set', retval=True)
+    def setVal(instance, val, oldVal, initiator):
+        validator = validators.get(inst.property.columns[0].type.__class__)
+        if validator:
+            return validator(val)
+
+        return val
+
+
 logger = createLog('core_model')
+
 
 class Core(object):
     """A mixin for other SQLAlchemy ORM classes. Includes a date_craeted and

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -339,3 +339,17 @@ class TestAgent(unittest.TestCase):
 
         newAlias = Alias.insertOrSkip(mock_session, 'Alias Name', mock_model, 1)
         self.assertEqual(newAlias.alias, 'Alias Name')
+    
+    # Name full integration tests
+
+    def test_new_agent_creation(self):
+        mockSession = MagicMock()
+        newAgent, roles = Agent.createAgent(
+            mockSession,
+            {
+                'name': 'Murry, Kathleen Beauchamp',
+                'roles': ['author']
+            }
+        )
+        self.assertEqual(newAgent.name, 'Murry, Kathleen Beauchamp')
+        self.assertEqual(roles[0], 'author')


### PR DESCRIPTION
Implements unicode normalization to "Normalization Form C" (NFC) by utilizing the `normalize` method from the built-in `unicodedata` library. This is implemented as a `listener` at the Base level of the postgreSQL ORM, validating all Unicode fields, whether passed as `bytes` or `str`

In python3.8 a new `is_normalized` method will be implemented allowing for easier checking of this. However, it is not necessary for this tool at the moment.

This will not update existing values in the database, a script will be written to validate/normalize existing values