### PR TITLE
SFR-571 move summary to instance

### DIFF
--- a/sfrCore/alembic/versions/ba19a561e368_remove_summaries_from_work_records_and_.py
+++ b/sfrCore/alembic/versions/ba19a561e368_remove_summaries_from_work_records_and_.py
@@ -1,0 +1,32 @@
+"""Remove summaries from Work records and place on instances
+
+Revision ID: ba19a561e368
+Revises: 4dee7066ba95
+Create Date: 2019-08-01 15:40:16.999177
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ba19a561e368'
+down_revision = '4dee7066ba95'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('work', 'summary')
+    op.add_column(
+        'instance',
+        sa.Column('summary', sa.Unicode)
+    )
+
+
+def downgrade():
+    op.drop_column('instance', 'summary')
+    op.add_column(
+        'work',
+        sa.Column('summary', sa.Unicode)
+    )

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -44,7 +44,8 @@ class Instance(Core, Base):
     table_of_contents = Column(Unicode)
     copyright_date = Column(Date)
     extent = Column(Unicode)
-    
+    summary = Column(Unicode)
+
     work_id = Column(Integer, ForeignKey('works.id'))
 
     work = relationship(

--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -49,7 +49,6 @@ class Work(Core, Base):
     medium = Column(Unicode)
     series = Column(Unicode)
     series_position = Column(Unicode)
-    summary = Column(Unicode)
 
     alt_titles = relationship(
         'AltTitle',

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -10,14 +10,18 @@ from sfrCore.model.instance import AgentInstances
 from sfrCore.helpers import DataError, DBError
 
 class InstanceTest(unittest.TestCase):
-
     def test_create_instance(self):
         testInst = Instance()
         testInst.title = 'Testing'
         testInst.edition = '1st ed'
+        testInst.summary = 'test summary'
 
-        self.assertEqual(str(testInst), '<Instance(title=Testing, edition=1st ed, work=None)>')
-    
+        self.assertEqual(
+            str(testInst),
+            '<Instance(title=Testing, edition=1st ed, work=None)>'
+        )
+        self.assertEqual(testInst.summary, 'test summary')
+
     def test_create_tmp(self):
         instanceData = {
             'formats': ['item1', 'item2'],

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,13 +1,9 @@
 import unittest
 from unittest.mock import patch, MagicMock, call, DEFAULT
-from collections import namedtuple
-
-from sqlalchemy.orm.exc import NoResultFound
 
 from sfrCore.model import Instance
 from sfrCore.model.instance import AgentInstances
 
-from sfrCore.helpers import DataError, DBError
 
 class InstanceTest(unittest.TestCase):
     def test_create_instance(self):
@@ -32,17 +28,21 @@ class InstanceTest(unittest.TestCase):
         self.assertEqual(testInst.tmp_formats[1], 'item2')
         self.assertEqual(len(testInst.tmp_agents), 3)
         self.assertEqual(testInst.items, set())
-    
+
     def test_remove_tmp(self):
         testInst = Instance()
         testInst.createTmpRelations({})
         testInst.tmp_agents = ['agent1', 'agent2']
         testInst.removeTmpRelations()
         with self.assertRaises(AttributeError):
-            tmpAgents = testInst.tmp_agents
+            testInst.tmp_agents
 
     @patch.object(Instance, 'lookup', return_value=None)
-    @patch.object(Instance, 'createNew', return_value=('newInstance', ['epub']))
+    @patch.object(
+        Instance,
+        'createNew',
+        return_value=('newInstance', ['epub'])
+    )
     def test_updateInsert_insert(self, mock_create, mock_lookup):
         mock_work = MagicMock()
         newInstance = Instance.updateOrInsert('session', {}, mock_work)
@@ -59,21 +59,21 @@ class InstanceTest(unittest.TestCase):
         oldInstance = Instance.updateOrInsert(mock_session, {}, mock_work)
         self.assertEqual(oldInstance, mock_instance)
         self.assertEqual(mock_work.epubsToLoad[0], 'epub')
-    
+
     @patch('sfrCore.model.instance.Identifier.getByIdentifier', return_value=1)
     def test_lookup_found(self, mock_get):
         mock_session = MagicMock()
         mock_session.query().filter().one.return_value = ('vol',)
         existingID = Instance.lookup(mock_session, [], 'vol')
         self.assertEqual(existingID, 1)
-    
+
     @patch('sfrCore.model.instance.Identifier.getByIdentifier', return_value=1)
     def test_lookup_not_found(self, mock_get):
         mock_session = MagicMock()
         mock_session.query().filter().one.return_value = ('vol',)
         existingID = Instance.lookup(mock_session, [], 'other_vol')
         self.assertEqual(existingID, None)
-    
+
     def test_add_new_item(self):
         mock_instance = MagicMock()
         mock_instance.items = set()
@@ -81,7 +81,7 @@ class InstanceTest(unittest.TestCase):
         mock_session.query().get.return_value = mock_instance
         Instance.addItemRecord(mock_session, 1, 'newItem')
         self.assertEqual(list(mock_instance.items)[0], 'newItem')
-    
+
     @patch.object(Instance, 'createTmpRelations')
     @patch.object(Instance, 'insertData', return_value=['epub'])
     @patch.object(Instance, 'removeTmpRelations')
@@ -96,22 +96,22 @@ class InstanceTest(unittest.TestCase):
         }
         testInstance = Instance()
         with patch.multiple(Instance,
-            cleanData=DEFAULT,
-            addAgents=DEFAULT,
-            addIdentifiers=DEFAULT,
-            addAltTitles=DEFAULT,
-            addMeasurements=DEFAULT,
-            addLinks=DEFAULT,
-            addDates=DEFAULT,
-            addRights=DEFAULT,
-            insertLanguages=DEFAULT,
-            insertItems=DEFAULT
-        ) as inst_mocks:
+                            cleanData=DEFAULT,
+                            addAgents=DEFAULT,
+                            addIdentifiers=DEFAULT,
+                            addAltTitles=DEFAULT,
+                            addMeasurements=DEFAULT,
+                            addLinks=DEFAULT,
+                            addDates=DEFAULT,
+                            addRights=DEFAULT,
+                            insertLanguages=DEFAULT,
+                            insertItems=DEFAULT
+                            ) as inst_mocks:
             inst_mocks['insertItems'].return_value = ['epub']
             newEpubs = testInstance.insertData(testData)
             self.assertEqual(testInstance.title, 'Test Instance')
             self.assertEqual(newEpubs, ['epub'])
-    
+
     def test_update(self):
         testData = {
             'title': 'New Instance'
@@ -120,25 +120,25 @@ class InstanceTest(unittest.TestCase):
         testInstance.title = 'Old Instance'
         testInstance.work = MagicMock()
         with patch.multiple(Instance,
-            setWorkFields=DEFAULT,
-            createTmpRelations=DEFAULT,
-            cleanData=DEFAULT,
-            updateAgents=DEFAULT,
-            updateIdentifiers=DEFAULT,
-            updateAltTitles=DEFAULT,
-            updateMeasurements=DEFAULT,
-            updateLinks=DEFAULT,
-            updateDates=DEFAULT,
-            updateRights=DEFAULT,
-            insertLanguages=DEFAULT,
-            insertItems=DEFAULT,
-            removeTmpRelations=DEFAULT
-        ) as inst_mocks:
+                            setWorkFields=DEFAULT,
+                            createTmpRelations=DEFAULT,
+                            cleanData=DEFAULT,
+                            updateAgents=DEFAULT,
+                            addIdentifiers=DEFAULT,
+                            updateAltTitles=DEFAULT,
+                            updateMeasurements=DEFAULT,
+                            updateLinks=DEFAULT,
+                            updateDates=DEFAULT,
+                            updateRights=DEFAULT,
+                            insertLanguages=DEFAULT,
+                            insertItems=DEFAULT,
+                            removeTmpRelations=DEFAULT
+                            ) as inst_mocks:
             inst_mocks['insertItems'].return_value = ['epub']
             newEpubs = testInstance.update('session', testData)
             self.assertEqual(testInstance.title, 'New Instance')
             self.assertEqual(newEpubs, ['epub'])
-    
+
     def test_set_work_fields(self):
         testInstance = Instance()
         mock_work = MagicMock()
@@ -148,13 +148,13 @@ class InstanceTest(unittest.TestCase):
         testInstance.setWorkFields('series', 'pos', testSubjects)
         self.assertEqual(testInstance.work.series, 'series')
         self.assertEqual(testInstance.work.series_position, 'pos')
-    
+
     def test_cleanData(self):
         testInstance = Instance()
         testInstance.pub_place = 'Boston : '
         testInstance.cleanData()
         self.assertEqual(testInstance.pub_place, 'Boston')
-    
+
     @patch.object(Instance, 'addAgent')
     def test_add_agents(self, mock_add):
         testInstance = Instance()
@@ -176,7 +176,7 @@ class InstanceTest(unittest.TestCase):
         mock_agent_instances.assert_has_calls([
             call(agent='agent1', instance=testInstance, role='tester')
         ])
-    
+
     @patch.object(Instance, 'updateAgent')
     def test_update_agents(self, mock_update):
         testInstance = Instance()
@@ -200,26 +200,31 @@ class InstanceTest(unittest.TestCase):
             call.roleExists(None, 'agent1', 'author', None),
             call(agent='agent1', instance=testInstance, role='author')
         ])
-        
-    @patch('sfrCore.model.Identifier.returnOrInsert', side_effect=[
-        MagicMock(), MagicMock()
-    ])
-    def test_add_identifiers(self, mock_identifier):
+
+    @patch('sfrCore.model.Instance.upsertIdentifier')
+    @patch('sfrCore.model.Instance.fetchUnglueitSummary')
+    def test_add_identifiers(self, mock_unglue, mock_identifier):
         testInst = Instance()
-        testInst.tmp_identifiers = ['id1', 'id2']
+        testInst.tmp_identifiers = [
+            {'value': 'id1', 'type': 'test'},
+            {'value': 'id2', 'type': 'isbn'}
+        ]
 
         testInst.addIdentifiers()
-        self.assertEqual(len(list(testInst.identifiers)), 2)
+        mock_unglue.assert_called_once_with('id2')
+        mock_identifier.assert_has_calls([
+            call(testInst.tmp_identifiers[0]),
+            call(testInst.tmp_identifiers[1])
+        ])
 
     @patch('sfrCore.model.instance.AltTitle', return_value='test_title')
     @patch.object(Instance, 'alt_titles', return_value=set('test_title'))
     def test_add_alt_title(self, mock_inst_alt, mock_alt):
-        
         testInst = Instance()
         testInst.tmp_alt_titles = ['test_title']
         testInst.addAltTitles()
         self.assertEqual(list(testInst.alt_titles)[0], 'test_title')
-    
+
     @patch('sfrCore.model.instance.Measurement')
     @patch.object(Instance, 'measurements', return_value=set('test_measure'))
     def test_add_measurement(self, mock_measures, mock_meas):
@@ -228,7 +233,7 @@ class InstanceTest(unittest.TestCase):
         testInst.tmp_measurements = ['measure1']
         testInst.addMeasurements()
         self.assertEqual(list(testInst.measurements)[0], 'test_measure')
-    
+
     @patch('sfrCore.model.instance.Link')
     @patch.object(Instance, 'links', return_value=set('test_link'))
     def test_add_link(self, mock_links, mock_link):
@@ -238,7 +243,7 @@ class InstanceTest(unittest.TestCase):
         testInst.tmp_links = [{'link': 'test_link'}]
         testInst.addLinks()
         self.assertEqual(list(testInst.links)[0], 'test_link')
-    
+
     @patch('sfrCore.model.instance.DateField')
     @patch.object(Instance, 'dates', return_value=set('test_date'))
     def test_add_date(self, mock_dates, mock_date):
@@ -248,7 +253,7 @@ class InstanceTest(unittest.TestCase):
         testInst.tmp_dates = ['1999-01-01']
         testInst.addDates()
         self.assertEqual(list(testInst.dates)[0], 'test_date')
-    
+
     @patch.object(Instance, 'insertLanguage')
     def test_insert_languages(self, mock_insert):
 
@@ -256,19 +261,18 @@ class InstanceTest(unittest.TestCase):
         testInst.tmp_language = 'lang1'
         testInst.insertLanguages()
         mock_insert.assert_called_with('lang1')
-    
+
     def test_insert_language(self):
-        with patch('sfrCore.model.instance.Language.updateOrInsert') as mock_lang:
+        with patch('sfrCore.model.instance.Language.updateOrInsert') as mock_lang:  # noqa: E501
             mock_insert = MagicMock()
             mock_lang.return_value = mock_insert
             testInst = Instance()
             testInst.insertLanguage('test_lang')
             self.assertEqual(list(testInst.language)[0], mock_insert)
-    
+
     @patch('sfrCore.model.instance.Rights')
     @patch.object(Instance, 'rights', return_value=set('test_rights'))
     def test_add_rights(self, mock_right, mock_rights):
-        
         mock_rights.insert.return_value = 'test_rights'
         testInst = Instance()
         testInst.tmp_rights = [{
@@ -277,7 +281,7 @@ class InstanceTest(unittest.TestCase):
         }]
         testInst.addRights()
         self.assertEqual(list(testInst.rights)[0], 'test_rights')
-    
+
     @patch('sfrCore.model.instance.Item.createOrStore', side_effect=[
         MagicMock(), MagicMock()
     ])
@@ -288,10 +292,11 @@ class InstanceTest(unittest.TestCase):
         newEpubs = testInst.insertItems()
         self.assertEqual(len(list(testInst.items)), 2)
         self.assertEqual(newEpubs, [])
-    
+
     def test_role_exists(self):
         mock_session = MagicMock()
-        mock_session.query().filter().filter().filter().one_or_none.return_value = 'test_role'
+        mock_session.query().filter().filter().filter()\
+            .one_or_none.return_value = 'test_role'
         mock_agent = MagicMock()
         mock_agent.id = 1
         role = AgentInstances.roleExists(mock_session, mock_agent, 'role', 1)

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -13,9 +13,7 @@ from sfrCore.helpers import DataError, DBError
 class WorkTest(unittest.TestCase):
     def test_work_init(self):
         testWork = Work()
-        testWork.summary = 'Summary'
         testWork.title = 'Testing'
-        self.assertEqual(testWork.summary, 'Summary')
         self.assertEqual(str(testWork), '<Work(title=Testing)>')
 
     def test_create_tmp(self):


### PR DESCRIPTION
Move the `summary` field from `Work` records to `Instance` records. This change more accurately reflects the use of summary entries, which frequently contain information and details on specific editions of a work. This change allows multiple summaries to be associated with each work, importantly allowing summaries in different languages to be made available.

These summaries are fetched from the unglue.it project's API. This API makes OPDS available which means a set of other metadata is available, notably subject headings but additionally other fields.