### PR TITLE
SFR-582 Fix duplicate link generation

### DIFF
--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,21 +1,25 @@
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 from sfrCore.model import Link
+
 
 class LinkTest(unittest.TestCase):
     def test_link_repr(self):
         testLink = Link()
-        testLink.url = 'testURL'
-        self.assertEqual(str(testLink), '<Link(url=testURL, media_type=None)>')
-    
+        testLink.url = 'http://testURL.edu'
+        self.assertEqual(
+            str(testLink),
+            '<Link(url=testurl.edu, media_type=None)>'
+        )
+
     @patch.object(Link, 'lookupLink', return_value=None)
     def test_link_updateInsert_insert(self, mock_lookup):
         fakeLink = {'url': 'testing'}
         testLink = Link.updateOrInsert('session', fakeLink, 'testing', 1)
         self.assertIsInstance(testLink, Link)
         self.assertEqual(testLink.url, 'testing')
-    
+
     @patch.object(Link, 'lookupLink')
     def test_link_updateInsert_update(self, mock_lookup):
         fakeLink = {'url': 'testing'}
@@ -23,14 +27,14 @@ class LinkTest(unittest.TestCase):
         mock_lookup.return_value = mock_existing
         testLink = Link.updateOrInsert('session', fakeLink, 'testing', 1)
         self.assertEqual(testLink, mock_existing)
-    
+
     def test_link_update(self):
         testLink = Link()
         testLink.url = 'oldURL'
 
         testLink.update({'url': 'newURL'})
-        self.assertEqual(testLink.url, 'newURL')
-    
+        self.assertEqual(testLink.url, 'newurl')
+
     def test_link_lookup(self):
         mock_session = MagicMock()
         mock_model = MagicMock()
@@ -38,3 +42,11 @@ class LinkTest(unittest.TestCase):
         mock_session.query().join().filter().filter().one_or_none.return_value = 'testLink'
         testLink = Link.lookupLink(mock_session, {'url': 'test'}, mock_model, 1)
         self.assertEqual(testLink, 'testLink')
+
+    def test_url_cleaner(self):
+        cleanLink = Link.httpRegexSub('https://www.nypl.org')
+        self.assertEqual(cleanLink, 'www.nypl.org')
+
+    def test_url_cleaner_lowercase(self):
+        cleanLink = Link.httpRegexSub('http://www.NYPL.org')
+        self.assertEqual(cleanLink, 'www.nypl.org')


### PR DESCRIPTION
This fixes two related bugs that potentially allow duplicate links to be associated with a single record (either `Work`, `Instance` or `Item`). These two issues are:

- Identical resources at `HTTP` and `HTTPS` addresses
- Capitalization issues

Both of these are addressed by implementing validation on the `url` column in the `links` table. Capitalization should never be used in URLs, however, as we are ingesting data from many different sources this cannot be trusted. The `HTTP/HTTPS` issue has come up repeatedly and this should prevent similar issues in the future