### PR TITLE
Hotfix high identifier counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.DEFAULT: help
+help:
+	@echo "make help"
+	@echo "    display this help statement"
+	@echo "make test"
+	@echo "    run pytest unit tests"
+	@echo "make build-layer"
+	@echo "    build new version of AWS Lambda Layer and deploy to AWS"
+	@echo "    select branch to build with as BRANCH=[branch_name]
+	@echo "make rebuild-docker"
+	@echo "    rebuild docker image with supplied keys at the provided name"
+	@echo "    This should use the following variables:"
+	@echo "    ACCESS_KEY=[aws_access_key]"
+	@echo "    SECRET_KEY=[aws_secret_access_key]"
+	@echo "    REGION=[aws_region]"
+	@echo "make lint"
+	@echo "    lint package with flake8"
+
+test:
+	pytest
+
+ifeq ($(BRANCH),)
+BRANCH = master
+endif
+build-layer:
+	@echo "Building AWS Layer from Branch: $(BRANCH)
+	docker run -e GIT_URL=git+https://github.com/NYPL/sfr-db-core.git@$(BRANCH)#egg=sfrCore -e LAYER_NAME=sfr-db-core-python-36-37-dev sfrcore
+
+rebuild-docker:
+	docker build -t sfrcore --build-arg accesskey=$(ACCESS_KEY) --build-arg secretkey=$(SECRET_KEY) --build-arg region=$(REGION) sfrCore
+
+lint:
+	flake8


### PR DESCRIPTION
A recent edge case exposed an issue in the `instance` class where several hundred ISBN records can cause the updater to hang as the core model attempts to find summaries for each of the ISBN records. This helps resolve the issue by streamlining the process so that only new identifiers are added to the set of existing identifiers and only those new ISBNs are queried for related summaries. While this has the immediate effect of limiting the number of queries made, it should also generally improve performance by limiting the number of requests made when adding identifiers.

This merge also adds a `Makefile` which should improve the development process for this module: 

- `make test` now runs the `pytest` module for clean test outputs
- `make rebuild-docker ACCESS_KEY=[aws_access] SECRET_KEY=[aws_secret] REGION=[aws_region]`: Creates the a docker image from the supplied Dockefile which can be used to create and deploy AWS-compatible versions of this module as a layer.
- `make build-layer BRANCH=[branch]` builds and deploys a new layer in AWS from the supplied branch. NOTE: This requires that the above command be run previously to create the docker image