### PR TITLE
Hotfix handle encrypted env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "    run pytest unit tests"
 	@echo "make build-layer"
 	@echo "    build new version of AWS Lambda Layer and deploy to AWS"
-	@echo "    select branch to build with as BRANCH=[branch_name]
+	@echo "    select branch to build with as BRANCH=[branch_name]"
 	@echo "make rebuild-docker"
 	@echo "    rebuild docker image with supplied keys at the provided name"
 	@echo "    This should use the following variables:"
@@ -23,8 +23,8 @@ ifeq ($(BRANCH),)
 BRANCH = master
 endif
 build-layer:
-	@echo "Building AWS Layer from Branch: $(BRANCH)
-	docker run -e GIT_URL=git+https://github.com/NYPL/sfr-db-core.git@$(BRANCH)#egg=sfrCore -e LAYER_NAME=sfr-db-core-python-36-37-dev sfrcore
+	@echo "Building AWS Layer from Branch: $(BRANCH)"
+	docker run -e GIT_URL=git+https://github.com/NYPL/sfr-db-core.git@$(BRANCH)\#egg=sfrCore -e LAYER_NAME=sfr-db-core-python-36-37-dev sfrcore
 
 rebuild-docker:
 	docker build -t sfrcore --build-arg accesskey=$(ACCESS_KEY) --build-arg secretkey=$(SECRET_KEY) --build-arg region=$(REGION) sfrCore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic
+boto3
 psycopg2-binary
 pycountry
 requests

--- a/sfrCore/lib/sessionManager.py
+++ b/sfrCore/lib/sessionManager.py
@@ -1,3 +1,7 @@
+from base64 import b64decode
+from binascii import Error as base64Error
+import boto3
+from botocore.exceptions import ClientError
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -5,19 +9,20 @@ from sqlalchemy.orm import sessionmaker
 from ..model.core import Base
 from ..helpers import createLog
 
+
 class SessionManager():
     def __init__(self, user=None, pswd=None, host=None, port=None, db=None):
-        self.user = user if user else os.environ.get('DB_USER', None)
-        self.pswd = pswd if pswd else os.environ.get('DB_PSWD', None)
-        self.host = host if host else os.environ.get('DB_HOST', None)
-        self.port = port if port else os.environ.get('DB_PORT', None)
-        self.db = db if db else os.environ.get('DB_NAME', None)
-        
+        self.user = user if user else SessionManager.decryptEnvVar('DB_USER')
+        self.pswd = pswd if pswd else SessionManager.decryptEnvVar('DB_PSWD')
+        self.host = host if host else SessionManager.decryptEnvVar('DB_HOST')
+        self.port = port if port else SessionManager.decryptEnvVar('DB_PORT')
+        self.db = db if db else SessionManager.decryptEnvVar('DB_NAME')
+
         self.engine = None
         self.session = None
-        
+
         self.logger = createLog('dbManager')
-    
+
     def generateEngine(self):
         try:
             self.engine = create_engine(
@@ -38,7 +43,8 @@ class SessionManager():
             Base.metadata.create_all(self.engine)
 
     def createSession(self, autoflush=True):
-        if not self.engine: self.generateEngine()
+        if not self.engine:
+            self.generateEngine()
         self.session = sessionmaker(bind=self.engine, autoflush=autoflush)()
         return self.session
 
@@ -47,7 +53,7 @@ class SessionManager():
 
     def commitChanges(self):
         self.session.commit()
-    
+
     def rollbackChanges(self):
         self.session.rollback()
 
@@ -55,3 +61,18 @@ class SessionManager():
         self.commitChanges()
         self.session.close()
         self.engine.dispose()
+
+    @staticmethod
+    def decryptEnvVar(envVar):
+        encrypted = os.environ.get(envVar, None)
+
+        try:
+            decoded = b64decode(encrypted)
+        except (TypeError, base64Error):
+            return encrypted
+
+        try:
+            return boto3.client('kms')\
+                .decrypt(CiphertextBlob=decoded)['Plaintext'].decode('utf-8')
+        except (ClientError, TypeError):
+            return decoded.decode('utf-8')

--- a/sfrCore/lib/sessionManager.py
+++ b/sfrCore/lib/sessionManager.py
@@ -72,7 +72,9 @@ class SessionManager():
             return encrypted
 
         try:
-            return boto3.client('kms')\
+            # If region is not set, assume us-east-1
+            regionName = os.environ.get('AWS_REGION', 'us-east-1')
+            return boto3.client('kms', region_name=regionName)\
                 .decrypt(CiphertextBlob=decoded)['Plaintext'].decode('utf-8')
         except (ClientError, TypeError):
             return decoded.decode('utf-8')

--- a/tests/test_sessionManager.py
+++ b/tests/test_sessionManager.py
@@ -1,11 +1,18 @@
+from base64 import b64encode
+import os
 import unittest
 from unittest.mock import patch, MagicMock
 
 from sfrCore.lib import SessionManager
 
+
 class SessionTest(unittest.TestCase):
     @patch('sfrCore.lib.sessionManager.createLog')
-    def test_init_local_vars(self, mock_log):
+    @patch('sfrCore.lib.sessionManager.SessionManager.decryptEnvVar')
+    def test_init_local_vars(self, mock_log, mock_decrypt):
+        def returnVal(value):
+            return value
+        mock_decrypt.side_effect = returnVal
         testManager = SessionManager(
             user='test',
             pswd='pswd',
@@ -87,3 +94,30 @@ class SessionTest(unittest.TestCase):
         mock_commit.assert_called_once()
         mock_session.close.assert_called_once()
         mock_engine.dispose.assert_called_once()
+
+    @patch.dict(
+        os.environ,
+        {'testing': b64encode('testing'.encode('utf-8')).decode('utf-8')}
+    )
+    @patch('sfrCore.lib.sessionManager.boto3')
+    def test_env_decryptor_success(self, mock_boto):
+        mock_boto.client().decrypt.return_value = {
+            'Plaintext': 'testing'.encode('utf-8')
+        }
+        outEnv = SessionManager.decryptEnvVar('testing')
+        self.assertEqual(outEnv, 'testing')
+
+    @patch.dict(os.environ, {'testing': 'testing'})
+    @patch('sfrCore.lib.sessionManager.boto3')
+    def test_env_decryptor_non_encoded(self, mock_boto):
+        mock_boto.client().decrypt.return_value = {'Plaintext': 'testing'}
+        outEnv = SessionManager.decryptEnvVar('testing')
+        self.assertEqual(outEnv, 'testing')
+
+    @patch.dict(
+        os.environ,
+        {'testing': b64encode('testing'.encode('utf-8')).decode('utf-8')}
+    )
+    def test_env_decryptor_boto_error(self):
+        outEnv = SessionManager.decryptEnvVar('testing')
+        self.assertEqual(outEnv, 'testing')

--- a/tests/test_sessionManager.py
+++ b/tests/test_sessionManager.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from botocore.exceptions import ClientError
 import os
 import unittest
 from unittest.mock import patch, MagicMock
@@ -118,6 +119,8 @@ class SessionTest(unittest.TestCase):
         os.environ,
         {'testing': b64encode('testing'.encode('utf-8')).decode('utf-8')}
     )
-    def test_env_decryptor_boto_error(self):
+    @patch('sfrCore.lib.sessionManager.boto3')
+    def test_env_decryptor_boto_error(self, mock_boto):
+        mock_boto.client().decrypt.side_effect = ClientError
         outEnv = SessionManager.decryptEnvVar('testing')
         self.assertEqual(outEnv, 'testing')


### PR DESCRIPTION
This commit adds handling for encrypted variables using the AWS KMS service to the session manager. This allows sensitive database credentials
to be committed to git in an encrypted form and used in a continuous deployment environment.

The change adds a static method to the `SessionManager` class that checks for a base64 encoded, encrypted string and decrypts it if found. If not, it simply returns the variable as is to allow for non-sensitive variables to be set for functions without requiring encryption. For example, an API endpoint can be added in plain text, it is not sensitive information.

To support this a new set of unit tests was added, and the `boto3` requirement was added to the pip file