### PR TITLE
SFR-590 Edition class bugfixes

### DIFF
--- a/sfrCore/alembic/versions/5e16c177ecef_add_created_modified_to_edtions.py
+++ b/sfrCore/alembic/versions/5e16c177ecef_add_created_modified_to_edtions.py
@@ -1,0 +1,35 @@
+"""Add created-modified to edtions
+
+Revision ID: 5e16c177ecef
+Revises: 5c49a8cf3064
+Create Date: 2019-09-09 15:39:07.773453
+
+"""
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5e16c177ecef'
+down_revision = '5c49a8cf3064'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'editions',
+        sa.Column('date_created', sa.DateTime, default=datetime.now())
+    )
+    op.add_column(
+        'editions',
+        sa.Column('date_modified',
+                  sa.DateTime, default=datetime.now(), onupdate=datetime.now())
+    )
+
+
+def downgrade():
+    op.drop_column('editions', 'date_created')
+    op.drop_column('editions', 'date_modified')

--- a/sfrCore/model/edition.py
+++ b/sfrCore/model/edition.py
@@ -81,7 +81,7 @@ class Edition(Core, Base):
     def loadPublishers(self):
         publishers = set()
         for instance in self.instances:
-            for agent in instance.instance_agents:
+            for agent in instance.agent_instances:
                 if agent.role == 'publisher':
                     publishers.add(agent.agent.name)
 

--- a/tests/test_editions.py
+++ b/tests/test_editions.py
@@ -64,13 +64,13 @@ class EditionTest(unittest.TestCase):
         mockAgent1.agent.name = 'Test, Tester'
         mockAgent2 = MagicMock()
         mockAgent2.role = 'other'
-        mockInst1.instance_agents = [mockAgent1, mockAgent2]
+        mockInst1.agent_instances = [mockAgent1, mockAgent2]
 
         mockInst2 = MagicMock()
-        mockInst2.instance_agents = [mockAgent1]
+        mockInst2.agent_instances = [mockAgent1]
 
         testEdition = Edition()
         testEdition.instances = {mockInst1, mockInst2}
         publishers = testEdition.loadPublishers()
-        
+
         self.assertEqual(publishers, 'Test, Tester')


### PR DESCRIPTION
This commit makes a few minor bugfixes to the `Edition` class:

- fix the transposed relational table call from `instance_agents` to `agent_instances`
- add the required columns `date_created` and `date_modified