### PR TITLE
SFR-703 Improve Identifier lookups

### DIFF
--- a/sfrCore/model/identifiers.py
+++ b/sfrCore/model/identifiers.py
@@ -310,9 +310,19 @@ class Identifier(Base):
 
         className = model.__tablename__[:-1]
 
-        cleanIdentifiers = [cls._cleanIdentifier(i) for i in identifiers]
+        cleanIdentifiers = []
+        for i in identifiers:
+            try:
+                cleanIdentifiers.append(cls._cleanIdentifier(i))
+            except DataError:
+                continue
+
         idQueries = []
         for iden in cleanIdentifiers:
+            logger.debug('Querying database for identifier {} ({})'.format(
+                iden['identifier'],
+                iden['type']
+            ))
             idenType = iden['type']
             idenValue = iden['identifier']
             idQueries.append(


### PR DESCRIPTION
Requests to the database layer to retrieve a record by an array of identifiers were executing a number of sequential queries that were then iterated over to extract the best match. This has been improved by marshalling all of these queries into a single request using `UNION ALL` to join them. This cuts the execution time of the operation roughly in half, and should enable other requests to more effectively make updates in the identifier tables.