### PR TITLE
HOTFIX Access Report

### DIFF
--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -367,7 +367,8 @@ class Item(Core, Base):
             if existingID is not None:
                 existing = session.query(Item).get(existingID)
                 newReport = Item.buildReport(aceReport)
-                existing.access_reports.add(newReport)
+                newReport.item = existing
+                session.add(newReport)
                 return newReport
 
     @classmethod

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -252,7 +252,7 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(list(testItem.rights)[0].name, 'test_rights')
     
     @patch('sfrCore.model.item.Identifier')
-    @patch.object(Item, 'buildReport', return_value='newReport')
+    @patch.object(Item, 'buildReport')
     def test_add_access_report(self, mock_build, mock_iden):
         testReport = {
             'identifier': 'item_id',
@@ -266,11 +266,11 @@ class ItemTest(unittest.TestCase):
         }
         mock_iden.getByidentifier.return_value = 1
         mock_session = MagicMock()
-        mock_item = MagicMock()
-        mock_item.access_reports = set()
-        mock_session.query().get.return_value=mock_item
+        mock_session.query().get.return_value = 'parentItem'
+        mockReport = MagicMock()
+        mock_build.return_value = mockReport
         Item.addReportData(mock_session, testReport)
-        self.assertEqual(list(mock_item.access_reports)[0], 'newReport')
+        self.assertEqual(mockReport.item, 'parentItem')
 
     def test_init_report(self):
         testReport = AccessReport(


### PR DESCRIPTION
The accessibility report generator was not creating a connection to the parent item record, this flips how the relationship is created to ensure that it is present for the manager function