### PR TITLE
SFR-703 general improvements

### DIFF
--- a/sfrCore/lib/sessionManager.py
+++ b/sfrCore/lib/sessionManager.py
@@ -34,6 +34,9 @@ class SessionManager():
                     self.db
                 )
             )
+            self.engine.execute(
+                'SET statement_timeout TO \'30s\'; SET lock_timeout TO\'15s\';'
+            )
         except Exception as e:
             self.logger.error(e)
             raise e
@@ -42,7 +45,7 @@ class SessionManager():
         if not self.engine.dialect.has_table(self.engine, 'works'):
             Base.metadata.create_all(self.engine)
 
-    def createSession(self, autoflush=True):
+    def createSession(self, autoflush=False):
         if not self.engine:
             self.generateEngine()
         self.session = sessionmaker(bind=self.engine, autoflush=autoflush)()

--- a/sfrCore/lib/sessionManager.py
+++ b/sfrCore/lib/sessionManager.py
@@ -3,7 +3,7 @@ from binascii import Error as base64Error
 import boto3
 from botocore.exceptions import ClientError
 import os
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from ..model.core import Base
@@ -34,9 +34,9 @@ class SessionManager():
                     self.db
                 )
             )
-            self.engine.execute(
+            self.engine.execute(text(
                 'SET statement_timeout TO \'30s\'; SET lock_timeout TO\'15s\';'
-            )
+            ))
         except Exception as e:
             self.logger.error(e)
             raise e

--- a/sfrCore/model/identifiers.py
+++ b/sfrCore/model/identifiers.py
@@ -317,25 +317,21 @@ class Identifier(Base):
             except DataError:
                 continue
 
-        idQueries = []
+        matches = defaultdict(int)
         for iden in cleanIdentifiers:
             logger.debug('Querying database for identifier {} ({})'.format(
                 iden['identifier'],
                 iden['type']
             ))
             idenType = iden['type'] if iden['type'] is not None else 'generic'
-            idenValue = iden['identifier']
-            idQueries.append(
-                'SELECT {}_id FROM {}_identifiers JOIN identifiers ON {}_identifiers.identifier_id = identifiers.id JOIN {} ON identifiers.id = {}.identifier_id WHERE {}.value=\'{}\''.format(
-                    className, className, className, idenType, idenType, idenType, idenValue
-                )
+            q = 'SELECT {}_id FROM {}_identifiers JOIN identifiers ON {}_identifiers.identifier_id = identifiers.id JOIN {} ON identifiers.id = {}.identifier_id WHERE {}.value=\'{}\''.format(
+                className, className, className, idenType,
+                idenType, idenType, iden['identifier']
             )
+            results = session.execute(text(q))
 
-        results = session.execute(text(' UNION ALL '.join(idQueries)))
-
-        matches = defaultdict(int)
-        for res in results:
-            matches[res[0]] += 1
+            for res in results:
+                matches[res[0]] += 1
 
         sortedMatches = sorted(
             matches.items(),

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -323,7 +323,9 @@ class Instance(Core, Base):
                     role,
                     self.id
                 ) is None:
-                    AgentInstances(agent=agentRec, instance=self, role=role)
+                    self.agents.add(
+                        AgentInstances(agent=agentRec, instance=self, role=role)
+                    )
         except DataError:
             logger.warning('Unable to read agent {}'.format(agent['name']))
 
@@ -344,10 +346,12 @@ class Instance(Core, Base):
 
         # Add new identifiers to set and check for summaries associated with
         # new identifiers being associated with this instance
-        for iden in list(identifiers):
-            self.identifiers.add(iden)
-            if iden.type == 'isbn':
-                self.fetchUnglueitSummary(iden.isbn[0].value)
+        ## Disabled for performance reasons
+        # for iden in list(identifiers):
+        #    self.identifiers.add(iden)
+        #    if iden.type == 'isbn':
+        #        self.fetchUnglueitSummary(iden.isbn[0].value)
+        ##
 
     def upsertIdentifier(self, iden):
         try:

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -323,7 +323,7 @@ class Instance(Core, Base):
                     role,
                     self.id
                 ) is None:
-                    self.agents.add(
+                    self.agents.append(
                         AgentInstances(agent=agentRec, instance=self, role=role)
                     )
         except DataError:

--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -346,12 +346,11 @@ class Instance(Core, Base):
 
         # Add new identifiers to set and check for summaries associated with
         # new identifiers being associated with this instance
-        ## Disabled for performance reasons
-        # for iden in list(identifiers):
-        #    self.identifiers.add(iden)
-        #    if iden.type == 'isbn':
-        #        self.fetchUnglueitSummary(iden.isbn[0].value)
-        ##
+        for iden in list(identifiers):
+            self.identifiers.add(iden)
+            ## Disabled for performance reasons
+            # if iden.type == 'isbn':
+            #    self.fetchUnglueitSummary(iden.isbn[0].value)
 
     def upsertIdentifier(self, iden):
         try:

--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -186,13 +186,12 @@ class Item(Core, Base):
         """Will query for existing items and either update or insert an item
         record pending the outcome of that query"""
 
-        existingID = Item.lookup(session, itemData['identifiers'])
+        existingItem = Item.lookup(session, itemData['identifiers'])
 
-        if existingID is not None:
+        if existingItem is not None:
             logger.debug('Found existing item by identifier')
-            existing = session.query(Item).get(existingID)
-            existing.update(session, itemData)
-            outItem = existing
+            existingItem.update(session, itemData)
+            outItem = existingItem
         else:
             logger.debug('Inserting new item record')
             outItem = Item.createItem(session, itemData)

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -223,7 +223,8 @@ class InstanceTest(unittest.TestCase):
         ]
 
         testInst.addIdentifiers()
-        mock_unglue.assert_called_once_with('testISBN')
+        # mock_unglue.assert_called_once_with('testISBN')
+        mock_unglue.assert_not_called()  # Temporarily disabled for performance
         mock_identifier.assert_has_calls([
             call(testInst.tmp_identifiers[0]),
             call(testInst.tmp_identifiers[1])

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -112,15 +112,14 @@ class ItemTest(unittest.TestCase):
         newItem = Item.updateOrInsert('session', testData)
         self.assertEqual(newItem, 'newItem')
     
-    @patch.object(Item, 'lookup', return_value=1)
+    @patch.object(Item, 'lookup')
     @patch.object(Item, 'update')
     def test_updateInsert_update(self, mock_update, mock_lookup):
         testData = {'identifiers': []}
         mock_item = MagicMock()
         mock_item.name = 'existingItem'
-        mock_session = MagicMock()
-        mock_session.query().get.return_value = mock_item
-        existingItem = Item.updateOrInsert(mock_session, testData)
+        mock_lookup.return_value = mock_item
+        existingItem = Item.updateOrInsert('session', testData)
         self.assertEqual(existingItem.name, 'existingItem')
     
     @patch.object(Item, 'createTmpRelations')

--- a/tests/test_sessionManager.py
+++ b/tests/test_sessionManager.py
@@ -30,11 +30,14 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(testManager.host, None)
         self.assertEqual(testManager.port, None)
 
-    @patch('sfrCore.lib.sessionManager.create_engine', return_value='newEngine')
+    @patch('sfrCore.lib.sessionManager.create_engine')
     def test_generate_engine_success(self, mock_engine):
+        mockEngine = MagicMock()
+        mock_engine.return_value = mockEngine
         testManager = SessionManager()
         testManager.generateEngine()
-        self.assertEqual(testManager.engine, 'newEngine')
+        testManager.engine.execute.assert_called_once()
+        self.assertEqual(testManager.engine, mockEngine)
 
     @patch('sfrCore.lib.sessionManager.create_engine', side_effect=Exception)
     def test_generate_engine_error(self, mock_engine):


### PR DESCRIPTION
This branch includes an array of minor fixes that support performance improvements for the ingest process. These are all either bug fixes of internal improvements, none of these change the functionality of the module at all. The changes and fixes include:

- Updated identifier lookup to increase efficiency in a concurrent query environment
- Set max lock timeout to prevent hanging queries and executions
- Set autoflush to false to prevent unnecessary round-trips to and from the database
- Fix handling of item and instance records now that the `lookup` methods return ORM objects
- Remove the instance summary lookup as a performance boosting measure (this may be temporary and can be rolled back at any time.
- Instance agents were being treated as a set when it is defined as a list