### PR TITLE
HOTFIX Agent Persistence

### DIFF
--- a/sfrCore/model/instance.py
+++ b/sfrCore/model/instance.py
@@ -323,7 +323,7 @@ class Instance(Core, Base):
                     role,
                     self.id
                 ) is None:
-                    self.agents.append(
+                    self.session.add(
                         AgentInstances(agent=agentRec, instance=self, role=role)
                     )
         except DataError:

--- a/sfrCore/model/item.py
+++ b/sfrCore/model/item.py
@@ -333,7 +333,9 @@ class Item(Core, Base):
         try:
             agentRec, roles = Agent.updateOrInsert(self.session, agent)
             for role in roles:
-                AgentItems(agent=agentRec, item=self, role=role)
+                self.session.add(
+                    AgentItems(agent=agentRec, item=self, role=role)
+                )
         except DataError:
             logger.warning('Unable to read agent {}'.format(agent['name']))
 

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -195,12 +195,14 @@ class InstanceTest(unittest.TestCase):
         mock_agent.updateOrInsert.return_value = ('agent1', None)
         mock_agent_instances.roleExists.return_value = None
         test_agent = {'name': 'agent1'}
-        testInstance = Instance()
+        mockSession = MagicMock()
+        testInstance = Instance(session=mockSession)
         testInstance.updateAgent(test_agent)
         mock_agent_instances.assert_has_calls([
-            call.roleExists(None, 'agent1', 'author', None),
+            call.roleExists(mockSession, 'agent1', 'author', None),
             call(agent='agent1', instance=testInstance, role='author')
         ])
+        mockSession.add.assert_called_once()
 
     @patch('sfrCore.model.Instance.upsertIdentifier')
     @patch('sfrCore.model.Instance.fetchUnglueitSummary')

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -193,7 +193,8 @@ class ItemTest(unittest.TestCase):
     @patch('sfrCore.model.item.Agent')
     @patch('sfrCore.model.item.AgentItems')
     def test_add_agent(self, mock_agent_items, mock_agent):
-        testItem = Item()
+        mockSession = MagicMock()
+        testItem = Item(session=mockSession)
         mock_name = MagicMock()
         mock_name.name = 'test_agent'
         mock_agent.updateOrInsert.return_value = (mock_name, ['tester'])
@@ -201,8 +202,8 @@ class ItemTest(unittest.TestCase):
         mock_agent_items.assert_has_calls([
             call(agent=mock_name, item=testItem, role='tester'),
         ])
-    
-    
+        mockSession.add.assert_called_once()
+
     @patch('sfrCore.model.item.Measurement')
     def test_add_measurement(self, mock_meas):
         testItem = Item()


### PR DESCRIPTION
Agents for instances and items were not being properly added to the records. As this is done through a relational table and is created with its relationships this can be added directly to the session.