### PR TITLE
SFR-703 remove viaf lookup

### DIFF
--- a/sfrCore/model/agent.py
+++ b/sfrCore/model/agent.py
@@ -376,6 +376,6 @@ class Alias(Core, Base):
                 .join(model)\
                 .filter(Alias.alias == alias)\
                 .filter(model.id == recordID)\
-                .one()
+                .first()
         except NoResultFound:
             return Alias(alias=alias)

--- a/sfrCore/model/agent.py
+++ b/sfrCore/model/agent.py
@@ -237,10 +237,10 @@ class Agent(Core, Base):
             None.
         """
 
+        agentID = None
         if self.viaf is not None or self.lcnaf is not None:
             agentID = self.authorityQuery()
-        else:
-            agentID = self.findViafQuery()
+
         if agentID is None:
             agentRec = self.findTrgmQuery()
             if agentRec:
@@ -273,21 +273,6 @@ class Agent(Core, Base):
         logger.info(
             'Name/information is too generic to create individual record'
         )
-
-        return None
-
-    def findViafQuery(self):
-        viafResp = requests.get('{}{}'.format(Agent.VIAF_API, self.name))
-        responseJSON = viafResp.json()
-        logger.debug(responseJSON)
-        if 'viaf' in responseJSON:
-            if responseJSON['name'] != self.name:
-                self.aliases.add(Alias(alias=self.name))
-                self.name = responseJSON.get('name', '')
-                self.cleanName()
-            self.viaf = responseJSON.get('viaf', None)
-            self.lcnaf = responseJSON.get('lcnaf', None)
-            return self.authorityQuery()
 
         return None
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -320,7 +320,7 @@ class TestAgent(unittest.TestCase):
     def test_alias_insert(self):
         mock_session = MagicMock()
         mock_session.query()\
-            .join().filter().filter().one.side_effect = NoResultFound
+            .join().filter().filter().first.side_effect = NoResultFound
         mock_model = MagicMock()
 
         newAlias = Alias.insertOrSkip(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -171,8 +171,7 @@ class TestAgent(unittest.TestCase):
         self.assertEqual(testAgent.sort_name, 'new, name')
 
     @patch.object(Agent, 'findTrgmQuery', return_value={'id': 'mockAgent'})
-    @patch.object(Agent, 'findViafQuery', return_value=None)
-    def test_agent_lookup_name(self, mock_viaf, mock_auth):
+    def test_agent_lookup_name(self, mock_auth):
         testAgent = Agent()
         testAgent.name = 'Tester, Test'
 
@@ -226,34 +225,6 @@ class TestAgent(unittest.TestCase):
         testAgent.name = 'Tester, Test'
         noMatches = testAgent.findTrgmQuery()
         self.assertEqual(noMatches, None)
-
-    @patch('sfrCore.model.agent.requests')
-    @patch.object(Agent, 'authorityQuery', return_value='matchedAgent')
-    @patch.object(Agent, 'cleanName')
-    def test_viaf_query_success(self, mock_clean, mock_auth, mock_req):
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            'name': 'Test',
-            'viaf': 000,
-            'lcnaf': 000
-        }
-        mock_req.get.return_value = mock_resp
-        testAgent = Agent()
-        testAgent.name = 'Old'
-        outAgent = testAgent.findViafQuery()
-        self.assertEqual(outAgent, 'matchedAgent')
-
-    @patch('sfrCore.model.agent.requests')
-    def test_viaf_query_miss(self, mock_req):
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            'message': 'Missing'
-        }
-        mock_req.get.return_value = mock_resp
-        testAgent = Agent()
-        testAgent.name = 'Old'
-        outAgent = testAgent.findViafQuery()
-        self.assertEqual(outAgent, None)
 
     def test_authority_query_success(self):
         mock_session = MagicMock()


### PR DESCRIPTION
This removes the VIAF/LCNAF lookup from the database model, transfering responsibilty for retrieving this data to the fetchers and enhancers. While this is less unified it is a better division of responsibilty and removes some of the database bottleneck where the database is responsible for making thousands of these requests