### PR TITLE
HOTFIX Handle language lists

### DIFF
--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -363,9 +363,9 @@ class Work(Core, Base):
             if isinstance(self.tmp_language, str):
                 self.tmp_language = [self.tmp_language]
 
-            self.language = {
-                self.addLanguage(l) for l in self.tmp_language
-            }
+            for lang in self.tmp_language:
+                print(self.addLanguage(lang))
+                self.language.update(self.addLanguage(lang))
 
     def addLanguage(self, language):
         try:
@@ -382,7 +382,7 @@ class Work(Core, Base):
                 self.updateLanguage(lang)
 
     def updateLanguage(self, lang):
-        self.language.extend(self.addLanguage(lang))
+        self.language.update(self.addLanguage(lang))
 
     def addAltTitles(self):
         self.alt_titles = {AltTitle(title=a) for a in self.tmp_alt_titles}

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -279,7 +279,7 @@ class WorkTest(unittest.TestCase):
         mock_val = MagicMock()
         mock_val.value = 'test_language'
 
-        mock_add.return_value = mock_val
+        mock_add.return_value = [mock_val]
 
         testWork.addLanguages()
         self.assertEqual(len(list(testWork.language)), 1)
@@ -292,7 +292,7 @@ class WorkTest(unittest.TestCase):
         mock_val = MagicMock()
         mock_val.value = 'test_language'
 
-        mock_add.return_value = mock_val
+        mock_add.return_value = [mock_val]
 
         testWork.addLanguages()
         self.assertEqual(len(list(testWork.language)), 1)


### PR DESCRIPTION
Update the `Work` class to handle multi-language strings (e.g. "eng;deu"). This is also necessary because the `Language` class now will always return a list, which to be merged into a set must use `update` instead of `add`