### PR TITLE
Sfr 703 internal instance lookup

### DIFF
--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -260,6 +260,7 @@ class Work(Core, Base):
 
     def updateInstances(self):
         logger.info('Upserting instances for work')
+        self.epubsToLoad = []
         instIDs = self.getLocalInstanceIdentifiers()
         for instance in self.tmp_instances:
             existing = self.matchLocalInstance(instance, instIDs)
@@ -272,7 +273,8 @@ class Work(Core, Base):
 
     def updateInstance(self, existing, newInst):
         try:
-            existing.update(self.session, newInst)
+            epubsToLoad = existing.update(self.session, newInst)
+            self.epubsToLoad.extend(epubsToLoad)
         except (DataError, DBError) as err:
             logger.warning('Unable to upsert instance record')
             logger.debug(err)

--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import re
 import uuid
 from sqlalchemy import (
@@ -249,23 +250,62 @@ class Work(Core, Base):
         logger.info('Adding instances to work')
         self.epubsToLoad = []
         for inst in self.tmp_instances:
-            newInstance, newEpubs = Instance.createNew(self.session, inst)
-            self.instances.add(newInstance)
-            self.epubsToLoad.extend(newEpubs)
+            self.addInstance(inst)
+
+    def addInstance(self, instance):
+        newInstance, newEpubs = Instance.createNew(self.session, instance)
+        self.instances.add(newInstance)
+        self.epubsToLoad.extend(newEpubs)
 
     def updateInstances(self):
         logger.info('Upserting instances for work')
+        instIDs = self.getLocalInstanceIdentifiers()
         for instance in self.tmp_instances:
-            self.updateInstance(instance)
+            existing = self.matchLocalInstance(instance, instIDs)
+            if existing:
+                self.updateInstance(existing, instance)
+            else:
+                self.addInstance(instance)
 
-    def updateInstance(self, inst):
+    def updateInstance(self, existing, newInst):
         try:
-            self.instances.add(
-                Instance.updateOrInsert(self.session, inst, work=self)
-            )
+            existing.update(self.session, newInst)
         except (DataError, DBError) as err:
             logger.warning('Unable to upsert instance record')
             logger.debug(err)
+
+    def getLocalInstanceIdentifiers(self):
+        instDict = {}
+        for inst in self.instances:
+            for iden in inst.identifiers:
+                idType = iden.type if iden.type else 'generic'
+                if idType in ['ddc', 'lcc']:
+                    continue
+                idRec = getattr(iden, idType)[0]
+                value = getattr(idRec, 'value')
+                idKey = '{}/{}'.format(idType, value)
+                instDict[idKey] = inst
+
+    def matchLocalInstance(self, inst, instDict):
+        matches = defaultdict(int)
+        for iden in inst['identifiers']:
+            idKey = '{}/{}'.format(iden['type'], iden['identfier'])
+            try:
+                matchInst = instDict[idKey]
+            except KeyError:
+                continue
+
+            matches[matchInst] += 1
+
+        sortedMatches = sorted(
+            matches.items(),
+            key=lambda x: x[1],
+            reverse=True
+        )
+        if len(sortedMatches) > 0:
+            return sortedMatches[0][0]
+
+        return None
 
     def addAgents(self):
         logger.info('Adding agents to work')

--- a/sfrCore/model/work.py
+++ b/sfrCore/model/work.py
@@ -286,10 +286,12 @@ class Work(Core, Base):
                 idKey = '{}/{}'.format(idType, value)
                 instDict[idKey] = inst
 
+        return instDict
+
     def matchLocalInstance(self, inst, instDict):
         matches = defaultdict(int)
         for iden in inst['identifiers']:
-            idKey = '{}/{}'.format(iden['type'], iden['identfier'])
+            idKey = '{}/{}'.format(iden['type'], iden['identifier'])
             try:
                 matchInst = instDict[idKey]
             except KeyError:

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -129,10 +129,12 @@ class WorkTest(unittest.TestCase):
         updateInstance=DEFAULT,
         addInstance=DEFAULT,
         getLocalInstanceIdentifiers=DEFAULT,
-        matchLocalInstance=DEFAULT
+        matchLocalInstance=DEFAULT,
+        addNewIdentifiers=DEFAULT
     )
     def test_update_instances(self, updateInstance, addInstance,
-                              getLocalInstanceIdentifiers, matchLocalInstance):
+                              getLocalInstanceIdentifiers, matchLocalInstance,
+                              addNewIdentifiers):
         testWork = Work()
         testWork.tmp_instances = ['inst1', 'inst2']
         existingInst = MagicMock()
@@ -141,6 +143,7 @@ class WorkTest(unittest.TestCase):
         getLocalInstanceIdentifiers.assert_called_once()
         updateInstance.assert_called_once_with(existingInst, 'inst2')
         addInstance.assert_called_once_with('inst1')
+        addNewIdentifiers.assert_called_twice()
 
     @patch('sfrCore.model.work.Instance')
     def test_update_instance(self, mockInst):

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -123,34 +123,136 @@ class WorkTest(unittest.TestCase):
 
         testWork.addInstances()
         self.assertEqual(list(testWork.instances)[0].name, 'testInstance')
-    
-    @patch.object(Work, 'updateInstance')
-    def test_update_instances(self, mock_update):
+
+    @patch.multiple(
+        Work,
+        updateInstance=DEFAULT,
+        addInstance=DEFAULT,
+        getLocalInstanceIdentifiers=DEFAULT,
+        matchLocalInstance=DEFAULT
+    )
+    def test_update_instances(self, updateInstance, addInstance,
+                              getLocalInstanceIdentifiers, matchLocalInstance):
         testWork = Work()
-        testWork.tmp_instances = ['inst1']
+        testWork.tmp_instances = ['inst1', 'inst2']
+        existingInst = MagicMock()
+        matchLocalInstance.side_effect = [None, existingInst]
         testWork.updateInstances()
-        mock_update.called_once_with('inst1')
-    
-    @patch('sfrCore.model.work.Instance')
-    def test_update_instance(self, mock_inst):
-        testWork = Work()
-        mock_val = MagicMock()
-        mock_val.value = 'testInst'
-        mock_inst.updateOrInsert.return_value = mock_val
+        getLocalInstanceIdentifiers.assert_called_once()
+        updateInstance.assert_called_once_with(existingInst, 'inst2')
+        addInstance.assert_called_once_with('inst1')
 
-        testWork.updateInstance('inst1')
-        self.assertEqual(list(testWork.instances)[0].value, 'testInst')
-    
     @patch('sfrCore.model.work.Instance')
-    def test_update_instance_err(self, mock_inst):
+    def test_update_instance(self, mockInst):
         testWork = Work()
-        mock_val = MagicMock()
-        mock_val.value = 'testInst'
-        mock_inst.updateOrInsert.side_effect = DataError('test err')
+        testWork.session = 'session'
 
-        testWork.updateInstance('inst1')
+        testWork.updateInstance(mockInst, 'newInst')
+
+        mockInst.update.assert_called_once_with('session', 'newInst')
+
+    @patch('sfrCore.model.work.Instance')
+    def test_update_instance_err(self, mockInst):
+        testWork = Work()
+        testWork.session = 'session'
+        mockInst.update.side_effect = DataError('test err')
+
+        testWork.updateInstance(mockInst, 'inst1')
         self.assertEqual(testWork.instances, set())
-    
+
+    def test_getLocalInstanceIdentifiers(self):
+        testWork = Work()
+        testInstances = []
+        for i in range(1, 3):
+            instIDs = []
+            for j in range(i*2, i*3):
+                mockID = MagicMock()
+                mockID.value = j
+                mockParent = MagicMock()
+                mockParent.type = 'test'
+                mockParent.test = [mockID]
+                instIDs.append(mockParent)
+
+            mockInst = MagicMock()
+            mockInst.identifiers = instIDs
+            testInstances.append(mockInst)
+
+        testWork.instances = set(testInstances)
+
+        idDict = testWork.getLocalInstanceIdentifiers()
+        self.assertEqual(len(idDict.keys()), 3)
+        self.assertEqual(sorted(list(idDict.keys()))[0], 'test/2')
+        self.assertEqual(sorted(list(idDict.items()))[0][1], testInstances[0])
+
+    def test_matchLocalInstance_foundMatch(self):
+        testDict = {
+            'test/1': 'inst1',
+            'test/2': 'inst1',
+            'test/4': 'inst3'
+        }
+        testInstance = {
+            'identifiers': [
+                {
+                    'type': 'test',
+                    'identifier': 1
+                }, {
+                    'type': 'other',
+                    'identifier': 1
+                }, {
+                    'type': 'test',
+                    'identifier': 2
+                }
+            ]
+        }
+        testWork = Work()
+        matchedInstance = testWork.matchLocalInstance(testInstance, testDict)
+        self.assertEqual(matchedInstance, 'inst1')
+
+    def test_matchLocalInstance_found_multiple(self):
+        testDict = {
+            'test/1': 'inst1',
+            'test/2': 'inst1',
+            'test/4': 'inst3'
+        }
+        testInstance = {
+            'identifiers': [
+                {
+                    'type': 'test',
+                    'identifier': 1
+                }, {
+                    'type': 'test',
+                    'identifier': 4
+                }, {
+                    'type': 'test',
+                    'identifier': 2
+                }
+            ]
+        }
+        testWork = Work()
+        matchedInstance = testWork.matchLocalInstance(testInstance, testDict)
+        self.assertEqual(matchedInstance, 'inst1')
+
+    def test_matchLocalInstance_no_match(self):
+        testDict = {
+            'test/1': 'inst1',
+            'test/2': 'inst1',
+            'test/4': 'inst3'
+        }
+        testInstance = {
+            'identifiers': [
+                {
+                    'type': 'other',
+                    'identifier': 1
+                }, {
+                    'type': 'other',
+                    'identifier': 2
+                }
+            ]
+        }
+        testWork = Work()
+        matchedInstance = testWork.matchLocalInstance(testInstance, testDict)
+        self.assertEqual(matchedInstance, None)
+
     @patch.object(Work, 'addIdentifier')
     def test_add_identifiers(self, mock_add):
         testWork = Work()

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -139,11 +139,15 @@ class WorkTest(unittest.TestCase):
         testWork.tmp_instances = ['inst1', 'inst2']
         existingInst = MagicMock()
         matchLocalInstance.side_effect = [None, existingInst]
+        getLocalInstanceIdentifiers.return_value = {}
+        addInstance.return_value = 'newInstance'
         testWork.updateInstances()
         getLocalInstanceIdentifiers.assert_called_once()
         updateInstance.assert_called_once_with(existingInst, 'inst2')
         addInstance.assert_called_once_with('inst1')
-        addNewIdentifiers.assert_called_twice()
+        addNewIdentifiers.assert_has_calls(
+            [call('newInstance', {}), call(existingInst, {})]
+        )
 
     @patch('sfrCore.model.work.Instance')
     def test_update_instance(self, mockInst):

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -152,6 +152,7 @@ class WorkTest(unittest.TestCase):
     @patch('sfrCore.model.work.Instance')
     def test_update_instance(self, mockInst):
         testWork = Work()
+        testWork.epubsToLoad = []
         testWork.session = 'session'
 
         testWork.updateInstance(mockInst, 'newInst')


### PR DESCRIPTION
The new flow for the backend has eliminated updates for "bare" instances that need to be matched and associated with the proper work. Because these instances come associated with the correct work this general lookup is redundant. It can be replaced with a check for existing instances with the current work and either update or insert based off the results of this check.

This check works in the same way as the current query functions, it checks and counts the number of matching identifiers and merges the new record with the existing record with the highest number of matches. If none are found it creates a new record. (`DDC` and `LCC` identifiers are excluded from this as the are of a more general nature.)

This change has two benefits. First, it should eliminate any possibility that an instance will be associated with the wrong work. We know the right work and take that for granted with this model. Second, it should greatly reduce the number of queries to the database. While these queries are relatively fast, 100ms or so, many are made. For a large work record we might make three such queries for 100 instances. All told this would add 30 seconds to the execution time for that record. By eliminating these queries we should see marked improvement in performance